### PR TITLE
修复默认异常捕获不到情况

### DIFF
--- a/src/annotation/Validate.php
+++ b/src/annotation/Validate.php
@@ -80,7 +80,7 @@ class Validate
             $this->setValidateScene();
             $validateFile = File::screen($validateFileMaps,$this->request->controller().'.'.$this->annotation['validate']);
             $this->rule = File::getObject($validateFile);
-            if ($this->rule == '') throw new \Exception("注解验证器错误. @validate('$this->annotation['validate']')不存在");
+            if (empty($this->rule)) throw new \Exception("注解验证器错误. @validate('$this->annotation['validate']')不存在");
         }catch (\Exception $exception){
             throw new \Exception($exception->getMessage());
         }

--- a/src/annotation/lib/ApiAnnotation.php
+++ b/src/annotation/lib/ApiAnnotation.php
@@ -37,6 +37,7 @@ class ApiAnnotation
             if (empty($apiFile)) return $this->data;
             foreach ($apiFile as $file) {
                 $this->object = File::getObject($file);
+                if ($this->object == false) continue;
                 $this->annotation = new Annotation($this->object);
                 $this->data[get_class($this->object)] = $this->get();
             }

--- a/src/exception/Exception.php
+++ b/src/exception/Exception.php
@@ -16,9 +16,10 @@ class Exception extends \Exception
     public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
         parent::__construct(
-            $message,
-            $code,
-            $previous);
+            $message ?? $this->message,
+            $code ?? $this->code,
+            $previous
+        );
     }
 
     public function getUserCode(): int

--- a/src/exception/Exception.php
+++ b/src/exception/Exception.php
@@ -16,8 +16,8 @@ class Exception extends \Exception
     public function __construct($message = "", $code = 0, Throwable $previous = null)
     {
         parent::__construct(
-            $message ?? $this->message,
-            $code ?? $this->code,
+            empty($message) ?$this->message : $message,
+            empty($code) ?$this->code : $code,
             $previous
         );
     }

--- a/src/utils/File.php
+++ b/src/utils/File.php
@@ -37,7 +37,7 @@ trait File
         $namespace = str_replace('.php', '', $namespace);
         $namespace = str_replace('/', '\\', $namespace);
         $namespace = str_replace('\\\\', '\\', $namespace);
-        if (class_exist($namespace)){
+        if (class_exists($namespace)){
             return new $namespace();
         }
         return false;

--- a/src/utils/File.php
+++ b/src/utils/File.php
@@ -37,7 +37,10 @@ trait File
         $namespace = str_replace('.php', '', $namespace);
         $namespace = str_replace('/', '\\', $namespace);
         $namespace = str_replace('\\\\', '\\', $namespace);
-        return new $namespace();
+        if (class_exist($namespace)){
+            return new $namespace();
+        }
+        return false;
     }
 
 

--- a/src/utils/Helper.php
+++ b/src/utils/Helper.php
@@ -43,7 +43,7 @@ trait Helper
      */
     static function getApiAnnotation(string $module)
     {
-        $apiFiles = Dir::getFiles(env('APP_PATH') . '/' . $module . '/' );
+        $apiFiles = Dir::getFiles(env('APP_PATH') . DIRECTORY_SEPARATOR . $module . DIRECTORY_SEPARATOR.config('url_controller_layer').DIRECTORY_SEPARATOR );
         $apiAnnotations = new ApiAnnotation($apiFiles);
         return $apiAnnotations->data;
     }


### PR DESCRIPTION
## 修复默认异常捕获不到情况

源代码：

```
<?php
/** Created By wene<china_wangyu@aliyun.com>, Data: 2019/7/16 */


namespace WangYu\exception;


use Throwable;

class Exception extends \Exception
{
    protected $message = '系统内部错误';
    protected $code = 400;
    protected $user_code = 1000;

    public function __construct($message = "", $code = 0, Throwable $previous = null)
    {
        parent::__construct(
            $message,
             $code,
            $previous);
    }

    public function getUserCode(): int
    {
        return $this->user_code ?? 1000;
    }
}
```

修整后：

```
<?php
/** Created By wene<china_wangyu@aliyun.com>, Data: 2019/7/16 */


namespace WangYu\exception;


use Throwable;

class Exception extends \Exception
{
    protected $message = '系统内部错误';
    protected $code = 400;
    protected $user_code = 1000;

    public function __construct($message = "", $code = 0, Throwable $previous = null)
    {
        parent::__construct(
            $message ?? $this->message,
            $code ?? $this->code,
            $previous
        );
    }

    public function getUserCode(): int
    {
        return $this->user_code ?? 1000;
    }
}
```

加上了默认为空取值，当前异常类定义`message`和`code`